### PR TITLE
signed char support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Data types are noted as it follows:
 - `f` is `float` (single percision)
 - `c` is `complexf` (two single precision floating point values in a struct) 
 - `u8` is `unsigned char` of 1 byte/8 bits (e. g. the output of `rtl_sdr` is of `u8`)
+- `i8` is `signed char` of 1 byte/8 bits (e. g. the output of `hackrf_transfer` is of `i8`)
 - `i16` is `signed short` of 2 bytes/16 bits (e. g. sound card input is usually `i16`)
 
 Functions usually end as:
@@ -122,6 +123,8 @@ The following commands are available:
 
 - `csdr convert_u8_f` 
 - `csdr convert_f_u8` 
+- `csdr convert_i8_f`
+- `csdr convert_f_i8`
 - `csdr convert_i16_f` 
 - `csdr convert_f_i16`
 

--- a/csdr.c
+++ b/csdr.c
@@ -57,6 +57,8 @@ char usage[]=
 "    convert_f_u8\n"
 "    convert_f_i16\n"
 "    convert_i16_f\n"
+"    convert_f_i8\n"
+"    convert_i8_f\n"
 "    realpart_cf\n"
 "    clipdetect_ff\n"
 "    limit_ff [max_amplitude]\n"
@@ -204,6 +206,7 @@ int main(int argc, char *argv[])
 {	
 	static float input_buffer[BIG_BUFSIZE*2];
 	static unsigned char buffer_u8[BIG_BUFSIZE*2];
+	static signed char buffer_i8[BIG_BUFSIZE*2];
 	static float output_buffer[BIG_BUFSIZE*2];
 	static short buffer_i16[BIG_BUFSIZE*2];
 	static float temp_f[BIG_BUFSIZE*4];
@@ -228,6 +231,28 @@ int main(int argc, char *argv[])
 			FREAD_R;
 			convert_f_u8(input_buffer, buffer_u8, BUFSIZE);
 			fwrite(buffer_u8, sizeof(unsigned char), BUFSIZE, stdout);
+			TRY_YIELD;
+		}
+	}
+	if(!strcmp(argv[1],"convert_f_i8"))
+	{
+		for(;;)
+		{
+			FEOF_CHECK;
+			FREAD_R;
+			convert_f_i8(input_buffer, buffer_i8, BUFSIZE);
+			fwrite(buffer_i8, sizeof(signed char), BUFSIZE, stdout);
+			TRY_YIELD;
+		}
+	}
+	if(!strcmp(argv[1],"convert_i8_f")) //not tested
+	{
+		for(;;)
+		{
+			FEOF_CHECK;
+			fread(buffer_i8, sizeof(signed char), BUFSIZE, stdin);
+			convert_i8_f(buffer_i8, output_buffer, BUFSIZE);
+			FWRITE_R;
 			TRY_YIELD;
 		}
 	}

--- a/libcsdr.c
+++ b/libcsdr.c
@@ -805,6 +805,11 @@ void convert_u8_f(unsigned char* input, float* output, int input_size)
 	for(int i=0;i<input_size;i++) output[i]=((float)input[i])/(UCHAR_MAX/2.0)-1.0; //@convert_u8_f
 }
 
+void convert_i8_f(signed char* input, float* output, int input_size)
+{
+	for(int i=0;i<input_size;i++) output[i]=((float)input[i])/SCHAR_MAX; //@convert_i8_f
+}
+
 void convert_i16_f(short* input, float* output, int input_size)
 {
 	for(int i=0;i<input_size;i++) output[i]=(float)input[i]/SHRT_MAX; //@convert_i16_f
@@ -817,6 +822,15 @@ void convert_f_u8(float* input, unsigned char* output, int input_size)
 	//of at least -60 dB is shown on the FFT plot after convert_f_u8 -> convert_u8_f
 }
 
+void convert_f_i8(float* input, signed char* output, int input_size)
+{
+	/*for(int i=0;i<input_size;i++)
+	{
+		if(input[i]>1.0) input[i]=1.0;
+		if(input[i]<-1.0) input[i]=-1.0;
+	}*/
+	for(int i=0;i<input_size;i++) output[i]=input[i]*SCHAR_MAX; //@convert_f_i8
+}
 void convert_f_i16(float* input, short* output, int input_size)
 {
 	/*for(int i=0;i<input_size;i++) 

--- a/libcsdr.h
+++ b/libcsdr.h
@@ -164,6 +164,8 @@ void gain_ff(float* input, float* output, int input_size, float gain);
 
 void convert_u8_f(unsigned char* input, float* output, int input_size);
 void convert_f_u8(float* input, unsigned char* output, int input_size);
+void convert_f_i8(float* input, signed char* output, int input_size);
+void convert_i8_f(signed char* input, float* output, int input_size);
 void convert_f_i16(float* input, short* output, int input_size);
 void convert_i16_f(short* input, float* output, int input_size);
 


### PR DESCRIPTION
Hi,

Thanks for a great library. The [HackRF](https://greatscottgadgets.com/hackrf/) uses signed 8 bit values rather than unsigned for its I/Q samples. I've added support for them.