### PR TITLE
Support for receivers providing real signal

### DIFF
--- a/csdr.c
+++ b/csdr.c
@@ -1366,13 +1366,11 @@ int main(int argc, char *argv[])
 
 	if(!strcmp(argv[1],"fft_fc"))
 	{
-		/* For real FFT, the parameter is the number of output complex bins
+		/*
+		For real FFT, the parameter is the number of output complex bins
 		instead of the actual FFT size.
-		Thus, the number of input samples used for each FFT is twice the given parameter
-		and for this reason, out_of_every_n_samples is also doubled
-		to get correct amount of overlap.
-		This is not very neat but makes it easier to replace fft_cc by fft_fc
-		in some applications. */
+		Number of input samples used for each FFT is twice the given parameter.
+		This makes it easier to replace fft_cc by fft_fc in some applications. */
 		if(argc<=3) return badsyntax("need required parameters (fft_out_size, out_of_every_n_samples)");
 		int fft_in_size=0, fft_out_size=0;
 		sscanf(argv[2],"%d",&fft_out_size);
@@ -1380,7 +1378,6 @@ int main(int argc, char *argv[])
 		fft_in_size = 2*fft_out_size;
 		int every_n_samples;
 		sscanf(argv[3],"%d",&every_n_samples);
-		every_n_samples *= 2;
 		int benchmark=0;
 		int octave=0;
 		window_t window = WINDOW_DEFAULT;

--- a/fft_fftw.h
+++ b/fft_fftw.h
@@ -22,6 +22,7 @@ struct fft_plan_s
 #include "libcsdr.h"
 
 FFT_PLAN_T* make_fft_c2c(int size, complexf* input, complexf* output, int forward, int benchmark);
+FFT_PLAN_T* make_fft_r2c(int size, float* input, complexf* output, int benchmark);
 void fft_execute(FFT_PLAN_T* plan);
 void fft_destroy(FFT_PLAN_T* plan);
 

--- a/libcsdr.c
+++ b/libcsdr.c
@@ -952,6 +952,13 @@ void apply_precalculated_window_c(complexf* input, complexf* output, int size, f
 	}
 }
 
+void apply_precalculated_window_f(float* input, float* output, int size, float *windowt)
+{
+	for(int i=0;i<size;i++) //@apply_precalculated_window_f
+	{
+		output[i] = input[i] * windowt[i];
+	}
+}
 
 void apply_window_f(float* input, float* output, int size, window_t window)
 {

--- a/libcsdr.h
+++ b/libcsdr.h
@@ -138,6 +138,7 @@ void rational_resampler_get_lowpass_f(float* output, int output_size, int interp
 float *precalculate_window(int size, window_t window);
 void apply_window_c(complexf* input, complexf* output, int size, window_t window);
 void apply_precalculated_window_c(complexf* input, complexf* output, int size, float *windowt);
+void apply_precalculated_window_f(float* input, float* output, int size, float *windowt);
 void apply_window_f(float* input, float* output, int size, window_t window);
 void logpower_cf(complexf* input, float* output, int size, float add_db);
 void accumulate_power_cf(complexf* input, float* output, int size);

--- a/libcsdr_gpl.h
+++ b/libcsdr_gpl.h
@@ -31,6 +31,7 @@ typedef struct shift_addition_data_s
 } shift_addition_data_t;
 shift_addition_data_t shift_addition_init(float rate);
 float shift_addition_cc(complexf *input, complexf* output, int input_size, shift_addition_data_t d, float starting_phase);
+float shift_addition_fc(float *input, complexf* output, int input_size, shift_addition_data_t d, float starting_phase);
 void shift_addition_cc_test(shift_addition_data_t d);
 
 float agc_ff(float* input, float* output, int input_size, float reference, float attack_rate, float decay_rate, float max_gain, short hang_time, short attack_wait_time, float gain_filter_alpha, float last_gain);


### PR DESCRIPTION
I've added functions for FFT and downconversion of real (i.e. not complex I/Q) signal. This helps implement receivers which, instead of I/Q, use a single ADC to digitize an intermediate frequency or use direct sampling of an RF signal.