### PR TITLE
Fixes: Mac OS X, compile lint, csdr additions for IQ files

### DIFF
--- a/libcsdr.c
+++ b/libcsdr.c
@@ -1537,7 +1537,7 @@ char psk31_varicode_decoder_push(unsigned long long* status_shr, unsigned char s
 {
     *status_shr=((*status_shr)<<1)|(!!symbol); //shift new bit in shift register
     //fprintf(stderr,"*status_shr = %llx\n", *status_shr);
-    if((*status_shr)&0xFFF==0) return 0;
+    if(((*status_shr)&0xFFF)==0) return 0;
     for(int i=0;i<n_psk31_varicode_items;i++)
     {
         //fprintf(stderr,"| i = %d | %llx ?= %llx | bitsall = %d\n", i, psk31_varicode_items[i].code<<2, (*status_shr)&psk31_varicode_masklen_helper[(psk31_varicode_items[i].bitcount+4)&63], (psk31_varicode_items[i].bitcount+4)&63);
@@ -2375,6 +2375,15 @@ void convert_s16_f(short* input, float* output, int input_size)
     for(int i=0;i<input_size;i++) output[i]=(float)input[i]/SHRT_MAX; //@convert_s16_f
 }
 
+void convert_s16_big_endian_f(short* input, float* output, int input_size)
+{
+    for(int i=0;i<input_size;i++) {
+        unsigned short ushort = input[i];
+        short sint = (short) ((ushort & 0xff) << 8) | ((ushort >> 8) & 0xff);
+        output[i]=(float)sint/SHRT_MAX; //@convert_s16_big_endian_f
+    }
+}
+
 void convert_f_u8(float* input, unsigned char* output, int input_size)
 {
     for(int i=0;i<input_size;i++) output[i]=input[i]*UCHAR_MAX*0.5+128; //@convert_f_u8
@@ -2395,6 +2404,15 @@ void convert_f_s16(float* input, short* output, int input_size)
         if(input[i]<-1.0) input[i]=-1.0;
     }*/
     for(int i=0;i<input_size;i++) output[i]=input[i]*SHRT_MAX; //@convert_f_s16
+}
+
+void convert_f_s16_big_endian(float* input, short* output, int input_size)
+{
+    for(int i=0;i<input_size;i++) {
+        unsigned short ushort = (unsigned short) (short) (input[i]*SHRT_MAX);
+        short sint = (short) ((ushort & 0xff) << 8) | ((ushort >> 8) & 0xff);
+        output[i]=sint; //@convert_f_s16_big_endian
+    }
 }
 
 void convert_i16_f(short* input, float* output, int input_size) { convert_s16_f(input, output, input_size); }
@@ -2470,7 +2488,7 @@ int deinit_get_random_samples_f(FILE* status)
     return fclose(status);
 }
 
-int firdes_cosine_f(float* taps, int taps_length, int samples_per_symbol)
+void firdes_cosine_f(float* taps, int taps_length, int samples_per_symbol)
 {
     //needs a taps_length 2 × samples_per_symbol + 1
     int middle_i=taps_length/2;
@@ -2479,7 +2497,7 @@ int firdes_cosine_f(float* taps, int taps_length, int samples_per_symbol)
     normalize_fir_f(taps, taps, taps_length);
 }
 
-int firdes_rrc_f(float* taps, int taps_length, int samples_per_symbol, float beta)
+void firdes_rrc_f(float* taps, int taps_length, int samples_per_symbol, float beta)
 {
     //needs an odd taps_length
     int middle_i=taps_length/2;
@@ -2515,12 +2533,12 @@ matched_filter_type_t matched_filter_get_type_from_string(char* input)
     return MATCHED_FILTER_DEFAULT;
 }
 
-float* add_ff(float* input1, float* input2, float* output, int input_size)
+void add_ff(float* input1, float* input2, float* output, int input_size)
 {
     for(int i=0;i<input_size;i++) output[i]=input1[i]+input2[i];
 }
 
-float* add_const_cc(complexf* input, complexf* output, int input_size, complexf x)
+void add_const_cc(complexf* input, complexf* output, int input_size, complexf x)
 {
     for(int i=0;i<input_size;i++)
     {
@@ -2539,3 +2557,20 @@ int trivial_vectorize()
     }
     return c[0];
 }
+
+#ifdef OSX
+#include <mach/clock.h>
+#include <mach/mach.h>
+
+int csdr_clock_gettime(clockid_t clock_is, struct timespec *tp)
+{
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    tp->tv_sec = mts.tv_sec;
+    tp->tv_nsec = mts.tv_nsec;
+    return 0;
+}
+#endif

--- a/libcsdr.h
+++ b/libcsdr.h
@@ -64,6 +64,13 @@ typedef struct complexf_s { float i; float q; } complexf;
 //they dropped M_PI in C99, so we define it:
 #define PI ((float)3.14159265358979323846)
 
+#ifdef OSX
+ //clock_gettime is supposed to be included starting with OSX 10.12 (Sierra)
+ #include <time.h>
+ #define clock_gettime(clock_id, tp) csdr_clock_gettime(clock_id, tp)
+ int csdr_clock_gettime(clockid_t clock_id, struct timespec *tp);
+#endif
+
 #define TIME_TAKEN(start,end) ((end.tv_sec-start.tv_sec)+(end.tv_nsec-start.tv_nsec)/1e9)
 
 //window
@@ -222,7 +229,9 @@ void convert_f_u8(float* input, unsigned char* output, int input_size);
 void convert_s8_f(signed char* input, float* output, int input_size);
 void convert_f_s8(float* input, signed char* output, int input_size);
 void convert_f_s16(float* input, short* output, int input_size);
+void convert_f_s16_big_endian(float* input, short* output, int input_size);
 void convert_s16_f(short* input, float* output, int input_size);
+void convert_s16_big_endian_f(short* input, float* output, int input_size);
 void convert_f_i16(float* input, short* output, int input_size);
 void convert_i16_f(short* input, float* output, int input_size);
 void convert_f_s24(float* input, unsigned char* output, int input_size, int bigendian);
@@ -386,7 +395,7 @@ FILE* init_get_random_samples_f();
 void get_random_samples_f(float* output, int output_size, FILE* status);
 void get_random_gaussian_samples_c(complexf* output, int output_size, FILE* status);
 int deinit_get_random_samples_f(FILE* status);
-float* add_ff(float* input1, float* input2, float* output, int input_size);
+void add_ff(float* input1, float* input2, float* output, int input_size);
 float total_logpower_cf(complexf* input, int input_size);
 float normalized_timing_variance_u32_f(unsigned* input, float* temp, int input_size, int samples_per_symbol, int initial_sample_offset, int debug_print);
 
@@ -398,14 +407,14 @@ typedef enum matched_filter_type_e
 
 #define MATCHED_FILTER_DEFAULT MATCHED_FILTER_RRC
 
-int firdes_cosine_f(float* taps, int taps_length, int samples_per_symbol);
-int firdes_rrc_f(float* taps, int taps_length, int samples_per_symbol, float beta);
+void firdes_cosine_f(float* taps, int taps_length, int samples_per_symbol);
+void firdes_rrc_f(float* taps, int taps_length, int samples_per_symbol, float beta);
 matched_filter_type_t matched_filter_get_type_from_string(char* input);
 int apply_real_fir_cc(complexf* input, complexf* output, int input_size, float* taps, int taps_length);
 void generic_slicer_f_u8(float* input, unsigned char* output, int input_size, int n_symbols);
 void plain_interpolate_cc(complexf* input, complexf* output, int input_size, int interpolation);;
 void normalize_fir_f(float* input, float* output, int length);
-float* add_const_cc(complexf* input, complexf* output, int input_size, complexf x);
+void add_const_cc(complexf* input, complexf* output, int input_size, complexf x);
 void pack_bits_1to8_u8_u8(unsigned char* input, unsigned char* output, int input_size);
 unsigned char pack_bits_8to1_u8_u8(unsigned char* input);
 void dbpsk_decoder_c_u8(complexf* input, unsigned char* output, int input_size);

--- a/tsmpool.cpp
+++ b/tsmpool.cpp
@@ -42,7 +42,7 @@ tsmthread_t* tsmpool::register_thread()
 	return thread;
 }
 
-int tsmpool::remove_thread(tsmthread_t* thread)
+void tsmpool::remove_thread(tsmthread_t* thread)
 {
 	pthread_mutex_lock(&this->mutex);
 	for(int i=0;i<threads.size();i++)

--- a/tsmpool.h
+++ b/tsmpool.h
@@ -36,7 +36,7 @@ public:
 	tsmpool(size_t size, int num);
 	void* get_write_buffer();
 	tsmthread_t* register_thread();
-	int remove_thread(tsmthread_t* thread);
+	void remove_thread(tsmthread_t* thread);
 	void* get_read_buffer(tsmthread_t* thread);
 	int index_next(int index) { return (index+1==num)?0:index+1; }
 	int index_before(int index) { return (index-1<0)?num-1:index-1; }


### PR DESCRIPTION
1) Runs on Mac OS X again.
2) OS X LLVM/Clang produced minor lint errors which were fixed.
3) Added big endian support to convert_s16_f, convert_f_s16 and added
iq_swap_ff for IQ sources (e.g. IQ files) that might need them.

Tested with:
OS X 10.11.6 (El Capitan)
Beagle Debian 8.5 (Linux 4.4.9)