### PR TITLE
Change return type of `remove_thread()` to void

### DIFF
--- a/tsmpool.cpp
+++ b/tsmpool.cpp
@@ -42,7 +42,7 @@ tsmthread_t* tsmpool::register_thread()
 	return thread;
 }
 
-int tsmpool::remove_thread(tsmthread_t* thread)
+void tsmpool::remove_thread(tsmthread_t* thread)
 {
 	pthread_mutex_lock(&this->mutex);
 	for(int i=0;i<threads.size();i++)

--- a/tsmpool.h
+++ b/tsmpool.h
@@ -36,7 +36,7 @@ public:
 	tsmpool(size_t size, int num);
 	void* get_write_buffer();
 	tsmthread_t* register_thread();
-	int remove_thread(tsmthread_t* thread);
+	void remove_thread(tsmthread_t* thread);
 	void* get_read_buffer(tsmthread_t* thread);
 	int index_next(int index) { return (index+1==num)?0:index+1; }
 	int index_before(int index) { return (index-1<0)?num-1:index-1; }


### PR DESCRIPTION
Flowing off the end of a function is undefined behavior. On Fedora 28,
the `nmux` program would segfault when this function returned.