### PR TITLE
allow 4 arguments to bpsk_costas_loop_cc

### DIFF
--- a/csdr.c
+++ b/csdr.c
@@ -2841,7 +2841,7 @@ int main(int argc, char *argv[])
         if(argc<=3) return badsyntax("need required parameter (damping_factor)");
         sscanf(argv[3],"%f",&damping_factor);
 
-        int decision_directed = !!(argc>4 && (!strcmp(argv[4], "--dd") || !strcmp(argv[5], "--decision_directed")));
+        int decision_directed = !!(argc>4 && (!strcmp(argv[4], "--dd") || !strcmp(argv[4], "--decision_directed")));
         if(decision_directed) { errhead(); fprintf(stderr, "decision directed mode\n"); }
 
         int output_error    =                  !!(argc>4+decision_directed && (!strcmp(argv[4+decision_directed], "--output_error")));

--- a/csdr.c
+++ b/csdr.c
@@ -233,7 +233,9 @@ int clone_(int bufsize_param)
         clone_buffer = (unsigned char*)malloc(bufsize_param*sizeof(unsigned char));
         for(;;)
         {
-            fread(clone_buffer, sizeof(unsigned char), bufsize_param, stdin);
+            if(fread(clone_buffer, sizeof(unsigned char), bufsize_param, stdin) <= 0) {
+              exit(0);
+	    }
             fwrite(clone_buffer, sizeof(unsigned char), bufsize_param, stdout);
             TRY_YIELD;
         }


### PR DESCRIPTION
without this patch, bpsk_costas_loop_cc crashes when given 4 arguments:

```
(gdb) run bpsk_costas_loop_cc 0.003 0.6 --output_nco
Starting program: /home/abob/csdr/csdr bpsk_costas_loop_cc 0.003 0.6 --output_nco

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7b7e75a in __strcmp_ssse3 () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ffff7b7e75a in __strcmp_ssse3 () from /lib64/libc.so.6
#1  0x000000000040b416 in main (argc=5, argv=0x7fffffffe388) at csdr.c:2844
```