### PR TITLE
disable the use of FFTW_MEASURE on all arm cpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ PARAMS_SSE = $(call cpufeature,sse,-msse) $(call cpufeature,sse2,-msse2) $(call 
 PARAMS_NEON = -mfloat-abi=hard -march=armv7-a -mtune=cortex-a8 -mfpu=neon -mvectorize-with-neon-quad -funsafe-math-optimizations -Wformat=0 -DNEON_OPTS
 #tnx Jan Szumiec for the Raspberry Pi support
 PARAMS_RASPI = -mfloat-abi=hard -mcpu=arm1176jzf-s -mfpu=vfp -funsafe-math-optimizations -Wformat=0
-PARAMS_ARM = $(if $(call cpufeature,BCM2708,dummy-text),$(PARAMS_RASPI),$(PARAMS_NEON))
+# since raspbian buster, fftw3 comes with the slow timer enabled, which causes troubles, so we have to disable FFTW_MEASURE
+PARAMS_ARM = $(if $(call cpufeature,BCM2708,dummy-text),$(PARAMS_RASPI),$(PARAMS_NEON)) -DCSDR_DISABLE_FFTW_MEASURE
 PARAMS_SIMD = $(if $(call cpufeature,sse,dummy-text),$(PARAMS_SSE),$(PARAMS_ARM))
 PARAMS_LOOPVECT = -O3 -ffast-math -fdump-tree-vect-details -dumpbase dumpvect
 PARAMS_LIBS = -g -lm -lrt -lfftw3f -DUSE_FFTW -DLIBCSDR_GPL -DUSE_IMA_ADPCM

--- a/fft_fftw.c
+++ b/fft_fftw.c
@@ -6,7 +6,7 @@
 FFT_PLAN_T* make_fft_c2c(int size, complexf* input, complexf* output, int forward, int benchmark)
 {
 	FFT_PLAN_T* plan=(FFT_PLAN_T*)malloc(sizeof(FFT_PLAN_T));
-	plan->plan = fftwf_plan_dft_1d(size, (fftwf_complex*)input, (fftwf_complex*)output, (forward)?FFTW_FORWARD:FFTW_BACKWARD, (benchmark)?FFTW_MEASURE:FFTW_ESTIMATE);
+	plan->plan = fftwf_plan_dft_1d(size, (fftwf_complex*)input, (fftwf_complex*)output, (forward)?FFTW_FORWARD:FFTW_BACKWARD, (benchmark)?CSDR_FFTW_MEASURE:FFTW_ESTIMATE);
 	plan->size=size;
 	plan->input=(void*)input;
 	plan->output=(void*)output;
@@ -16,7 +16,7 @@ FFT_PLAN_T* make_fft_c2c(int size, complexf* input, complexf* output, int forwar
 FFT_PLAN_T* make_fft_r2c(int size, float* input, complexf* output, int benchmark) //always forward DFT
 {
 	FFT_PLAN_T* plan=(FFT_PLAN_T*)malloc(sizeof(FFT_PLAN_T));
-	plan->plan = fftwf_plan_dft_r2c_1d(size, input, (fftwf_complex*)output, (benchmark)?FFTW_MEASURE:FFTW_ESTIMATE);
+	plan->plan = fftwf_plan_dft_r2c_1d(size, input, (fftwf_complex*)output, (benchmark)?CSDR_FFTW_MEASURE:FFTW_ESTIMATE);
 	plan->size=size;
 	plan->input=(void*)input;
 	plan->output=(void*)output;
@@ -26,7 +26,7 @@ FFT_PLAN_T* make_fft_r2c(int size, float* input, complexf* output, int benchmark
 FFT_PLAN_T* make_fft_c2r(int size, complexf* input, float* output, int benchmark) //always backward DFT
 {
 	FFT_PLAN_T* plan=(FFT_PLAN_T*)malloc(sizeof(FFT_PLAN_T));
-	plan->plan = fftwf_plan_dft_c2r_1d(size, (fftwf_complex*)input, output, (benchmark)?FFTW_MEASURE:FFTW_ESTIMATE);
+	plan->plan = fftwf_plan_dft_c2r_1d(size, (fftwf_complex*)input, output, (benchmark)?CSDR_FFTW_MEASURE:FFTW_ESTIMATE);
 	plan->size=size;
 	plan->input=(void*)input;
 	plan->output=(void*)output;

--- a/fft_fftw.h
+++ b/fft_fftw.h
@@ -26,4 +26,22 @@ FFT_PLAN_T* make_fft_r2c(int size, float* input, complexf* output, int benchmark
 void fft_execute(FFT_PLAN_T* plan);
 void fft_destroy(FFT_PLAN_T* plan);
 
+/*
+ * FFTW_MEASURE is inacceptably slow when there is no hardware cycle counter
+ * available. Unfortunately, there's no way to detect this at compile- or
+ * runtime.
+ *
+ * CSDR_DISABLE_FFTW_MEASURE can therefore be used to disable the use of
+ * FFTW_MEASURE globally.
+ *
+ * additional information: http://www.fftw.org/fftw3_doc/Cycle-Counters.html
+ *
+ * https://github.com/simonyiszk/openwebrx/issues/139
+ */
+#ifdef CSDR_DISABLE_FFTW_MEASURE
+#define CSDR_FFTW_MEASURE FFTW_ESTIMATE
+#else
+#define CSDR_FFTW_MEASURE FFTW_MEASURE
+#endif
+
 #endif


### PR DESCRIPTION
this is a problem that is showing up on raspbian buster, where recent fftw3* packages have been compiled with the `--with-slow-timer` option.

i would prefer to have a more precise way of telling if the slow timer is enabled, but i have found no trace of that flag in the includes that are packaged; nothing in pkgconfig, either.

see: https://github.com/simonyiszk/openwebrx/issues/139 for full discussion.