### PR TITLE
Makefile: create target folders before using them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ clean-vect:
 clean: clean-vect
 	rm -f libcsdr.so.$(SOVERSION) csdr ddcd nmux *.o *.so
 install: all 
+	install -d $(PREFIX)/lib
 	install -m 0755 libcsdr.so.$(SOVERSION) $(PREFIX)/lib
+	install -d $(PREFIX)/bin
 	install -m 0755 csdr $(PREFIX)/bin
 	install -m 0755 csdr-fm $(PREFIX)/bin
 	install -m 0755 nmux $(PREFIX)/bin


### PR DESCRIPTION
When installing to an "empty" filesystem (as is the case with fakeroots and
attempting to create installable packages), the ${PREFIX}/usr and ${PREFIX}/lib
directories need to be created (using "install -d").

Without the patch, if the filesystem is entirely empty, "libcsdr.so" gets
installed as "/lib" and "nmux" is installed as "/bin".

This was discovered as I modified the csdr sources to be usable with yocto
(this works, btw - you can check it out here https://github.com/adrians/meta-strat/tree/master/recipes-ham/csdr).

73 DE YO3IPJ