### PR TITLE
minor cleanups to make it more cross platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 
 LIBSOURCES =  fft_fftw.c libcsdr_wrapper.c 
 #SOURCES = csdr.c $(LIBSOURCES)
-cpufeature = $(if $(findstring $(1),$(shell cat /proc/cpuinfo)),$(2))
+cpufeature = $(if $(findstring $(1),$(shell list_cpu_features)),$(2))
 PARAMS_SSE = $(call cpufeature,sse,-msse) $(call cpufeature,sse2,-msse2) $(call cpufeature,sse3,-msse3) $(call cpufeature,sse4a,-msse4a) $(call cpufeature,sse4_1,-msse4.1) $(call cpufeature,sse4_2,-msse4.2 -msse4) -mfpmath=sse 
 PARAMS_NEON = -mfloat-abi=hard -march=armv7-a -mtune=cortex-a8 -mfpu=neon -mvectorize-with-neon-quad -funsafe-math-optimizations -Wformat=0 -DNEON_OPTS
 #tnx Jan Szumiec for the Raspberry Pi support

--- a/csdr.c
+++ b/csdr.c
@@ -188,7 +188,7 @@ char usage[]=
 
 int env_csdr_fixed_bufsize = 1024;
 int env_csdr_fixed_big_bufsize = 1024*16;
-#if __FreeBSD__
+#if !__linux__
 int env_csdr_dynamic_bufsize_on = 1;
 #else
 int env_csdr_dynamic_bufsize_on = 0;
@@ -373,8 +373,7 @@ int initialize_buffers()
 
     if(the_bufsize<=4096) //this is hacky, should be done correctly
     {
-#if __FreeBSD__
-#else
+#if __linux__
         fcntl(STDIN_FILENO, F_SETPIPE_SZ,  4096);
         fcntl(STDOUT_FILENO, F_SETPIPE_SZ, 4096);
 #endif
@@ -387,8 +386,7 @@ int sendbufsize(int size)
 {
     if(size<=4096)
     {
-#if __FreeBSD__
-#else
+#if __linux__
         fcntl(STDOUT_FILENO, F_SETPIPE_SZ, 4096);
 #endif
     }
@@ -436,8 +434,7 @@ int main(int argc, char *argv[])
     if(argc<=1) return badsyntax(0);
     if(!strcmp(argv[1],"--help")) return badsyntax(0);
 
-#if __FreeBSD__
-#else
+#if __linux__
     fcntl(STDIN_FILENO, F_SETPIPE_SZ, 65536*32);
     fcntl(STDOUT_FILENO, F_SETPIPE_SZ, 65536*32);
 #endif

--- a/csdr.c
+++ b/csdr.c
@@ -188,7 +188,11 @@ char usage[]=
 
 int env_csdr_fixed_bufsize = 1024;
 int env_csdr_fixed_big_bufsize = 1024*16;
+#if __FreeBSD__
+int env_csdr_dynamic_bufsize_on = 1;
+#else
 int env_csdr_dynamic_bufsize_on = 0;
+#endif
 int env_csdr_print_bufsizes = 0;
 int bigbufs = 0;
 
@@ -366,11 +370,16 @@ int initialize_buffers()
     buffer_u8 =     (unsigned char*)malloc(the_bufsize*sizeof(unsigned char));
     buffer_i16 =    (short*)        malloc(the_bufsize*sizeof(short));
     temp_f =        (float*)        malloc(the_bufsize*sizeof(float) * 4);
+
     if(the_bufsize<=4096) //this is hacky, should be done correctly
     {
+#if __FreeBSD__
+#else
         fcntl(STDIN_FILENO, F_SETPIPE_SZ,  4096);
         fcntl(STDOUT_FILENO, F_SETPIPE_SZ, 4096);
+#endif
     }
+
     return the_bufsize;
 }
 
@@ -378,7 +387,10 @@ int sendbufsize(int size)
 {
     if(size<=4096)
     {
+#if __FreeBSD__
+#else
         fcntl(STDOUT_FILENO, F_SETPIPE_SZ, 4096);
+#endif
     }
     //The first word is a preamble, "csdr".
     //If the next csdr process detects it, sets the buffer size according to the second word
@@ -424,8 +436,11 @@ int main(int argc, char *argv[])
     if(argc<=1) return badsyntax(0);
     if(!strcmp(argv[1],"--help")) return badsyntax(0);
 
+#if __FreeBSD__
+#else
     fcntl(STDIN_FILENO, F_SETPIPE_SZ, 65536*32);
     fcntl(STDOUT_FILENO, F_SETPIPE_SZ, 65536*32);
+#endif
     //fprintf(stderr, "csdr: F_SETPIPE_SZ\n");
 
     if(!strcmp(argv[1],"setbuf"))

--- a/csdr.c
+++ b/csdr.c
@@ -1793,15 +1793,31 @@ int main(int argc, char *argv[])
         //initialize FFT library, and measure time
         errhead(); fprintf(stderr,"initializing... ");
         struct timespec start_time, end_time;
+#if __FreeBSD__
+        clock_gettime(CLOCK_MONOTONIC_FAST, &start_time);
+#else
         clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
+#endif
         FFT_PLAN_T* plan=make_fft_c2c(fft_size,input,output,1,benchmark);
+#if __FreeBSD__
+        clock_gettime(CLOCK_MONOTONIC_FAST, &end_time);
+#else
         clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
+#endif
         fprintf(stderr,"done in %g seconds.\n",TIME_TAKEN(start_time,end_time));
 
         //do the actual measurement about the FFT
+#if __FreeBSD__
+        clock_gettime(CLOCK_MONOTONIC_FAST, &start_time);
+#else
         clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
+#endif
         for(int i=0;i<fft_cycles;i++) fft_execute(plan);
+#if __FreeBSD__
+        clock_gettime(CLOCK_MONOTONIC_FAST, &end_time);
+#else
         clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
+#endif
         float time_taken_fft = TIME_TAKEN(start_time,end_time);
         errhead(); fprintf(stderr,"%d transforms of %d processed in %g seconds, %g seconds each.\n",fft_cycles,fft_size,time_taken_fft,time_taken_fft/fft_cycles);
         return 0;
@@ -2004,11 +2020,19 @@ int main(int argc, char *argv[])
             if(flowcontrol_is_buffering)
             {
                 fprintf(stderr, "flowcontrol: buffering, flowcontrol_bufindex = %d\n", flowcontrol_bufindex);
+#if __FreeBSD__
+                if(flowcontrol_bufindex==flowcontrol_bufsize) { flowcontrol_is_buffering = 0; clock_gettime(CLOCK_MONOTONIC_FAST, &start_time); }
+#else
                 if(flowcontrol_bufindex==flowcontrol_bufsize) { flowcontrol_is_buffering = 0; clock_gettime(CLOCK_MONOTONIC_RAW, &start_time); }
+#endif
                 else if(read_return<=0) continue;
             }
             else {
+#if __FreeBSD__
+                clock_gettime(CLOCK_MONOTONIC_FAST, &end_time);
+#else
                 clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
+#endif
                 int thrust_added=0;
                 while( (all_bytes_written+thrust*flowcontrol_readsize) / TIME_TAKEN(start_time,end_time) < data_rate )
                 {
@@ -2063,11 +2087,19 @@ int main(int argc, char *argv[])
             if(!time_now_sec)
             {
                 time_now_sec=1;
+#if __FreeBSD__
+                clock_gettime(CLOCK_MONOTONIC_FAST, &start_time);
+#else
                 clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
+#endif
             }
             else
             {
+#if __FreeBSD__
+                clock_gettime(CLOCK_MONOTONIC_FAST, &end_time);
+#else
                 clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
+#endif
                 float timetaken;
                 if(time_now_sec<(timetaken=TIME_TAKEN(start_time,end_time)))
                 {

--- a/parsevect
+++ b/parsevect
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 print "" # python2.7 is required to run parsevect instead of python3
 """
 This software is part of libcsdr, a set of simple DSP routines for 


### PR DESCRIPTION
Uses list_cpu_features instead to get CPU features. Calling /proc/cpuinfo is a bad linuxism as lots of systems don't use that.

Use /usr/bin/env to invoke python2 instead of staticly coding the path. This avoids relying on a system installing python2 /usr/bin.